### PR TITLE
fix(db): repair demo creds and add run-once migration system

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -92,6 +92,13 @@ node -e "console.log(require('crypto').randomBytes(48).toString('hex'))"
    Re-run this after any release that adds tables, or the server logs
    `Database connection or schema migration failed` on boot.
 
+   New tables are handled by `schema.sql` (`CREATE TABLE IF NOT EXISTS`). To
+   **alter an existing table** (add a column/index), drop an ordered file in
+   `backend/database/migrations/` — `db:schema`/`db:setup` apply each one exactly
+   once, tracked in a `schema_migrations` table. Migrations are additive and
+   never re-run, so re-running the command is always safe on prod. See
+   `backend/database/migrations/README.md`.
+
 6. Confirm it is healthy: `curl https://<your-app>.up.railway.app/health` → `{"status":"ok"}`.
 
 ## 3. Frontend — Vercel

--- a/backend/database/fix-demo-credentials.sql
+++ b/backend/database/fix-demo-credentials.sql
@@ -1,0 +1,10 @@
+-- One-off fix: reset the three demo accounts to the documented password (Test@1234).
+-- Safe to run against any environment; only touches the demo rows and is idempotent.
+INSERT INTO users (full_name, email, password, user_role) VALUES
+  ('Test Admin',   'admin@test.com',   '$2b$10$tvyWXLNdUaSj68emJVYUF.4Eh65vsQbevgt/YtMNQJntnOqo5T/Gq', 'Admin'),
+  ('Test Student', 'student@test.com', '$2b$10$2m7LHysaBoHokx4Fb0P16.DFJpaWJ3neJJOUQ7Wy8bfVriEKNGtjC', 'Student'),
+  ('Test Tutor',   'tutor@test.com',   '$2b$10$pQb.FxTr2AGoZhzkQS9Q3eqPMrdsmRwFgHmbafR/1A/wgTsf34TxC', 'Tutor')
+ON DUPLICATE KEY UPDATE
+  password  = VALUES(password),
+  full_name = VALUES(full_name),
+  user_role = VALUES(user_role);

--- a/backend/database/migrations/001-courses-owner-user-id.sql
+++ b/backend/database/migrations/001-courses-owner-user-id.sql
@@ -1,0 +1,30 @@
+-- 001 — add courses.owner_user_id so a course can point at its owning user.
+-- Idempotent: the runner records each file as applied and never re-runs it, but
+-- these guards also make the file safe to run by hand against an older database
+-- that already went through the old ad-hoc bootstrap block.
+
+-- Add the column only if it is missing.
+SET @col := (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'courses' AND COLUMN_NAME = 'owner_user_id'
+);
+SET @sql := IF(@col = 0,
+    'ALTER TABLE courses ADD COLUMN owner_user_id INT DEFAULT NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Add the foreign key only if it is missing.
+SET @fk := (
+    SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'courses'
+      AND CONSTRAINT_NAME = 'fk_courses_owner'
+);
+SET @sql := IF(@fk = 0,
+    'ALTER TABLE courses ADD CONSTRAINT fk_courses_owner FOREIGN KEY (owner_user_id) REFERENCES users(id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Best-effort backfill from author display names for rows that predate the column.
+UPDATE courses c JOIN users u ON u.full_name = c.author
+SET c.owner_user_id = u.id
+WHERE c.owner_user_id IS NULL;

--- a/backend/database/migrations/README.md
+++ b/backend/database/migrations/README.md
@@ -1,0 +1,25 @@
+# Incremental migrations
+
+Ordered, run-once schema changes for databases that **already exist**.
+
+`schema.sql` creates tables from scratch (`CREATE TABLE IF NOT EXISTS`) and is
+enough for a brand-new database. It cannot, however, add a column or index to a
+table that is already there. That is what this folder is for.
+
+## How it works
+
+`npm run db:setup` / `npm run db:schema` applies `schema.sql`, then runs every
+`*.sql` file in this folder **in filename order**. Each file that succeeds is
+recorded in a `schema_migrations` table and is **never run again**. Nothing here
+is ever dropped or re-applied, so it is safe on production.
+
+## Adding a migration for a new feature
+
+1. Create the next numbered file, e.g. `002-add-something.sql`.
+2. Write only **additive** SQL — `ALTER TABLE ... ADD COLUMN`, `CREATE INDEX`,
+   `CREATE TABLE IF NOT EXISTS`. Avoid `DROP`/destructive changes on prod.
+3. Also add the final column/table to `schema.sql` so fresh installs get it too.
+4. Commit both. The next deploy runs the new file once, automatically.
+
+Keep files idempotent where you can (guard with `information_schema` checks like
+`001`) so a hand-run against a partially-migrated database is still safe.

--- a/backend/migrations/sqls/20230420120257-projectDB-up.sql
+++ b/backend/migrations/sqls/20230420120257-projectDB-up.sql
@@ -97,7 +97,7 @@ create table IF NOT EXISTS course_objectives(
     FOREIGN KEY(course_id) REFERENCES courses(id)
 );
 
-INSERT INTO users(full_name,email,password,user_role) VALUES('Test Admin','admin@test.com','$2b$10$0Wj/MmXpVOWEDiqA7WgY2.rWCUADDrKLZmJ4aGWtZvCMbTLbOSE.C','Admin'),('Test Student','student@test.com','$2b$10$Y43eTtQyTcCzilM3QO.s8eqqJKLS5c1VoWxuPGYg7PWgKej.mQMrK','Student'),('Test Tutor','tutor@test.com','$2b$10$ZaTklmXHQHZKfv9fO7j6FOtVVu9TjTbzRPqd646yUYK3DPhz40xne','Tutor');
+INSERT INTO users(full_name,email,password,user_role) VALUES('Test Admin','admin@test.com','$2b$10$tvyWXLNdUaSj68emJVYUF.4Eh65vsQbevgt/YtMNQJntnOqo5T/Gq','Admin'),('Test Student','student@test.com','$2b$10$2m7LHysaBoHokx4Fb0P16.DFJpaWJ3neJJOUQ7Wy8bfVriEKNGtjC','Student'),('Test Tutor','tutor@test.com','$2b$10$pQb.FxTr2AGoZhzkQS9Q3eqPMrdsmRwFgHmbafR/1A/wgTsf34TxC','Tutor') ON DUPLICATE KEY UPDATE password=VALUES(password),full_name=VALUES(full_name),user_role=VALUES(user_role);
 
 INSERT INTO `courses` (`id`, `author`, `category`, `price`, `rating`, `subtitle`, `thumb_url`, `title`)
     VALUES (10010, 'Vimlesh Kumar', 'Development', '1117.99', '4.50',

--- a/backend/scripts/db-bootstrap.js
+++ b/backend/scripts/db-bootstrap.js
@@ -14,12 +14,13 @@
  */
 import { bootstrapSecrets } from '../config/secrets.bootstrap.js';
 import mysql from 'mysql2/promise';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const databaseDir = join(__dirname, '..', 'database');
+const migrationsDir = join(databaseDir, 'migrations');
 
 // Top-level await, so the credentials below are read *after* configuration has
 // resolved — including secrets pulled from Infisical. The cache is irrelevant to
@@ -53,6 +54,50 @@ function resolveSsl() {
     return undefined;
 }
 
+/**
+ * Apply ordered, run-once SQL migrations from database/migrations/.
+ *
+ * Every *.sql file is run in filename order; each success is recorded in a
+ * schema_migrations table so it is never applied twice. Migrations are additive
+ * (ALTER ... ADD, CREATE ...) — nothing here drops data, so this is safe on
+ * production and idempotent across redeploys.
+ */
+async function runMigrations(connection) {
+    await connection.query(
+        `CREATE TABLE IF NOT EXISTS schema_migrations (
+            filename VARCHAR(255) PRIMARY KEY,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )`
+    );
+
+    let entries;
+    try {
+        entries = await readdir(migrationsDir);
+    } catch (err) {
+        if (err.code === 'ENOENT') return; // no migrations folder yet
+        throw err;
+    }
+
+    const files = entries.filter((f) => f.endsWith('.sql')).sort((a, b) => a.localeCompare(b));
+    if (files.length === 0) return;
+
+    const [applied] = await connection.query('SELECT filename FROM schema_migrations');
+    const done = new Set(applied.map((r) => r.filename));
+
+    let ran = 0;
+    for (const file of files) {
+        if (done.has(file)) continue;
+        const sql = await readFile(join(migrationsDir, file), 'utf8');
+        await connection.query(sql);
+        await connection.query('INSERT INTO schema_migrations (filename) VALUES (?)', [file]);
+        console.log(`✅ Migration applied: ${file}`);
+        ran++;
+    }
+    if (ran === 0) {
+        console.log('⏭️  Migrations up to date.');
+    }
+}
+
 async function run() {
     if (!MYSQL_DATABASE) {
         throw new Error('MYSQL_DATABASE is not set. Configure your .env (or host env vars) first.');
@@ -84,24 +129,10 @@ async function run() {
     await connection.query(schema);
     console.log('✅ Schema applied.');
 
-    // `CREATE TABLE IF NOT EXISTS` leaves existing tables untouched, so columns
-    // added after a database was first created need an explicit migration.
-    const [[{ hasOwnerColumn }]] = await connection.query(
-        `SELECT COUNT(*) AS hasOwnerColumn FROM information_schema.COLUMNS
-         WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'courses' AND COLUMN_NAME = 'owner_user_id'`,
-        [MYSQL_DATABASE]
-    );
-    if (!hasOwnerColumn) {
-        await connection.query('ALTER TABLE courses ADD COLUMN owner_user_id INT DEFAULT NULL');
-        await connection.query(
-            'ALTER TABLE courses ADD CONSTRAINT fk_courses_owner FOREIGN KEY (owner_user_id) REFERENCES users(id)'
-        );
-        // Best effort: display names are not unique, new courses store the owner directly.
-        await connection.query(
-            'UPDATE courses c JOIN users u ON u.full_name = c.author SET c.owner_user_id = u.id WHERE c.owner_user_id IS NULL'
-        );
-        console.log('✅ Added courses.owner_user_id (backfilled from author names).');
-    }
+    // `CREATE TABLE IF NOT EXISTS` leaves existing tables untouched, so changes
+    // to tables that already exist (new columns, indexes) live as ordered,
+    // run-once files in database/migrations/ — applied here.
+    await runMigrations(connection);
 
     if (schemaOnly) {
         console.log('⏭️  Seed data skipped (--schema-only).');


### PR DESCRIPTION
The three demo accounts failed to log in because two seed sources disagreed on the bcrypt hashes: database/seed.sql held the correct Test@1234 hashes, but the legacy db-migrate seed had stale/unknown ones and used a non-idempotent INSERT. Production was seeded via the migrate path, so Test@1234 returned 401 for all three.

- Align the legacy migration seed with seed.sql and make it idempotent (ON DUPLICATE KEY UPDATE).
- Add database/fix-demo-credentials.sql to repair existing prod rows.
- Add a run-once migration runner in db-bootstrap.js: ordered files in database/migrations/ tracked by a schema_migrations table, applied exactly once. Additive-only, never dropped/re-run — safe on prod.
- Move the ad-hoc courses.owner_user_id block into 001, guarded with information_schema checks so it is a no-op where the column exists.
- Document the workflow in DEPLOY.md and migrations/README.md.